### PR TITLE
Kmeans array key fix.

### DIFF
--- a/src/Phpml/Clustering/KMeans.php
+++ b/src/Phpml/Clustering/KMeans.php
@@ -1,6 +1,6 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
 
 namespace Phpml\Clustering;
 
@@ -45,7 +45,7 @@ class KMeans implements Clusterer
      */
     public function cluster(array $samples)
     {
-        $space = new Space(count($samples[0]));
+        $space = new Space(count($samples[array_key_first($samples)]));
         foreach ($samples as $sample) {
             $space->addPoint($sample);
         }


### PR DESCRIPTION
Fixed array issue when using arrays which have defined id's as per the doc for kmeans from https://php-ml.readthedocs.io/en/master/machine-learning/clustering/k-means/

Initially it didn't work as it didn't find the array key.